### PR TITLE
Use `indexPathForItemAtPoint:` for long press.

### DIFF
--- a/DraggableCollectionView.podspec
+++ b/DraggableCollectionView.podspec
@@ -1,0 +1,12 @@
+Pod::Spec.new do |s|
+  s.name         = "DraggableCollectionView"
+  s.version      = "0.1"
+  s.summary      = "Extension for the UICollectionView and UICollectionViewLayout that allows a user to move items with drag and drop."
+  s.homepage     = "https://github.com/pbernery/DraggableCollectionView"
+  s.license      = { :type => 'MIT', :file => 'LICENSE' }
+  s.authors      = [ 'Luke Scott', 'Rex Sheng' ]
+  s.source       = { :git => "https://github.com/pbernery/DraggableCollectionView.git" }
+  s.platform     = :ios, '6.0'
+  s.requires_arc = true
+  s.source_files = 'DraggableCollectionView', 'DraggableCollectionView/**/*.{h,m}'
+end

--- a/DraggableCollectionView/Helpers/LSCollectionViewHelper.m
+++ b/DraggableCollectionView/Helpers/LSCollectionViewHelper.m
@@ -218,8 +218,8 @@ typedef NS_ENUM(NSInteger, _ScrollingDirection) {
         return;
     }
     
-    NSIndexPath *indexPath = [self indexPathForItemClosestToPoint:[sender locationInView:self.collectionView]];
-    
+    NSIndexPath *indexPath = [self.collectionView indexPathForItemAtPoint:[sender locationInView:self.collectionView]];
+        
     switch (sender.state) {
         case UIGestureRecognizerStateBegan: {
             if (indexPath == nil) {


### PR DESCRIPTION
handleLongPressGesture: was using indexPathForItemClosestToPoint: method to
retrieve the index path of the pressed cell. This works well on layouts
that fill the entire collection view space but not on other layouts: in the
latter case, the closest cell will be selected whereas this is the one under the
finger we want to be selected.

It now uses indexPathForItemAtPoint: instead of
indexPathForItemClosestToPoint: to get the touched cell.

An by the way, your lib is awesome: I added dragging in a complex layout in a couple of hours.
